### PR TITLE
Direct uploaded items to mushroom detail page

### DIFF
--- a/client/components/LegalDisclaimer.js
+++ b/client/components/LegalDisclaimer.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+
+const Disclaimer = () => {
+  return (
+    <View className='flex-1 bg-gray-100 pt-5 pb-10'>
+        <View className='flex-row gap-2'>
+            <MaterialCommunityIcons name='gavel' size={30} color="brown" />
+            <Text className='text-2xl font-bold mb-5'>
+                Legal Disclaimer
+            </Text>
+        </View>
+
+        <Text className='text-base leading-6 mb-4'>
+            Even experts get it wrong sometimes. All the information we provide is as well researched as it can be, but we use image recognition technology, and it can make mistakes. Make sure to rely on your own judgement.
+        </Text>
+
+        <Text className='text-base leading-6 mb-4'>
+            Under no circumstance shall we have any liability to you for any loss or damage of any kind incurred as a result of the use of the app or reliance on any information provided. Your use of the app and your reliance on any information on the app is solely at your own risk.
+        </Text>
+
+        <Text className='text-base font-bold text-center mt-5'>
+            By using this app, you agree to the terms of this disclaimer.
+        </Text>
+    </View>
+  );
+};
+
+export default Disclaimer;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "react": "18.2.0",
         "react-native": "0.74.5",
         "react-native-gesture-handler": "^2.20.0",
+        "react-native-markdown-display": "^7.0.2",
         "react-native-paper": "^5.12.5",
         "react-native-reanimated": "^3.15.3",
         "react-native-safe-area-context": "^4.11.0",
@@ -6534,6 +6535,12 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/env-editor": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz",
@@ -8868,6 +8875,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9092,6 +9108,22 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
     "node_modules/marky": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
@@ -9128,6 +9160,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==",
+      "license": "MIT"
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "license": "MIT"
     },
     "node_modules/memoize-one": {
@@ -10996,6 +11034,15 @@
         }
       }
     },
+    "node_modules/react-native-fit-image": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz",
+      "integrity": "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==",
+      "license": "Beerware",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "node_modules/react-native-gesture-handler": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.0.tgz",
@@ -11009,6 +11056,22 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-markdown-display": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz",
+      "integrity": "sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-to-react-native": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "prop-types": "^15.7.2",
+        "react-native-fit-image": "^1.5.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-native": ">=0.50.4"
       }
     },
     "node_modules/react-native-paper": {
@@ -12789,6 +12852,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-gesture-handler": "^2.20.0",
+    "react-native-markdown-display": "^7.0.2",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "^3.15.3",
     "react-native-safe-area-context": "^4.11.0",

--- a/client/screens/HomeScreen.js
+++ b/client/screens/HomeScreen.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { View, Text, FlatList, Image } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, Text, FlatList, Image, TouchableOpacity } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useRoute } from '@react-navigation/native'; // Import useRoute
+import { useNavigation, useRoute } from '@react-navigation/native'; // Import useRoute
 import axios from 'axios';
 
 // Example data for the feed
@@ -27,10 +27,15 @@ export default function HomeScreen() {
   const route = useRoute(); // Get the route object
   const { username } = route.params || {}; // Extract username from params
 
+  const navigation = useNavigation(); // Get the navigation object
+
   useEffect(() => {
     (async () => {
       try {
         const response = await axios.get('http://192.168.0.110:8080/posts');
+        if (posts.length > 2) {
+          posts.splice(2); // remove all except mocked data before re-fetching posts
+        }
         for (let i = 0; i < response.data.length; i++) {
           const newPost = response.data[i];
           posts.push(newPost);
@@ -45,7 +50,10 @@ export default function HomeScreen() {
   }, []);
 
   const renderItem = ({ item }) => (
-    <View className="bg-white p-4 mb-4 rounded-lg shadow-md">
+    <TouchableOpacity className="bg-white p-4 mb-4 rounded-lg shadow-md" onPress={() => navigation.navigate('Campfire', {
+      screen: 'MushroomDetail',   // MushroomDetail is nested in Campfire screen
+      params: { id: '', item },  // Hard-coding id as an empty string, so that mocked data still renders
+    })}>
       <Text className="text-lg font-semibold">{item.user || 'Guest'}</Text>
       <Text className="text-sm text-gray-600">{item.name}</Text>
       <Image
@@ -53,7 +61,7 @@ export default function HomeScreen() {
         className="w-full h-48 rounded-lg my-2"
       />
       <Text className="text-gray-800">{item.description || 'Add description'}</Text>
-    </View>
+    </TouchableOpacity>
   );
 
   return (

--- a/client/screens/MushroomDetail.js
+++ b/client/screens/MushroomDetail.js
@@ -2,6 +2,8 @@ import React, {useState} from 'react';
 import { ScrollView, View, Text, Image, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import axios from 'axios';
+import Disclaimer from '../components/LegalDisclaimer';
+import Markdown from 'react-native-markdown-display';
 
 // Sample mushroom details data
 const mushroomDetails = {
@@ -53,8 +55,18 @@ const mushroomDetails = {
 };
 
 const MushroomDetail = ({ route, navigation }) => {
-  const { mushroomId } = route.params;
-  const mushroom = mushroomDetails[mushroomId];
+  const { mushroomId, item } = route.params;
+
+  let mushroom;
+  if (mushroomId) {
+    mushroom = mushroomDetails[mushroomId];
+  } else {
+    // debugging: console.log('Item details: ', item)
+    mushroom = { ...item };
+    mushroom.name = 'Oyster mushroom'; // hard-coding until cv model is integrated
+    mushroom.image = item.imageUrl;
+    mushroom.description = 'Description';
+  }
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false); // State to manage loading
 
@@ -63,7 +75,7 @@ const MushroomDetail = ({ route, navigation }) => {
     setResponse(''); // Clear previous response
 
     try {
-      const res = await axios.post('http://192.168.50.169:8080/chat', { prompt });
+      const res = await axios.post('http://192.168.0.110:8080/chat', { prompt });
       setResponse(res.data.response);
     } catch (error) {
       console.error('Error fetching response:', error);
@@ -73,17 +85,22 @@ const MushroomDetail = ({ route, navigation }) => {
     }
   };
 
-
   return (
-      <ScrollView className="flex-1 p-4  bg-gray-100">
-          
-          <Image
-              source={{ uri: mushroom.image }}
-              className="w-full h-48 rounded-xl mb-4"
-              resizeMode="cover"
-          />
-          <Text className="text-2xl font-bold">{mushroom.name}</Text>
-          <Text className="text-lg text-gray-700 mt-2">{mushroom.description}</Text>
+    <ScrollView className="flex-1 p-4  bg-gray-100">
+      <TouchableOpacity
+      className='flex-row mt-2 mb-2 gap-2 items-center'
+      onPress={() => navigation.navigate('Campfire Home')}
+      >
+        <Icon name='arrow-back' size={20} />
+        <Text className='text-lg font-semibold'>Return to database</Text>
+      </TouchableOpacity>
+      <Image
+          source={{ uri: mushroom.image }}
+          className="w-full h-48 rounded-xl mb-4"
+          resizeMode="cover"
+      />
+      <Text className="text-2xl font-bold">{mushroom.name}</Text>
+      <Text className="text-lg text-gray-700 mt-2">{mushroom.description}</Text>
 
       <View className="flex-row justify-between mt-4 space-x-2">
         <TouchableOpacity
@@ -107,11 +124,11 @@ const MushroomDetail = ({ route, navigation }) => {
           className="flex-row items-center bg-rose-100 p-4 border-2 rounded-full"
         >
           <Icon name="location-on" size={20} color="#FF7E70" />
-          <Text className="text-slate-800 ml-2">Where to Find</Text>
-          </TouchableOpacity>
-        </View>
+          <Text className="text-slate-800 ml-2">Locations</Text>
+        </TouchableOpacity>
+      </View>
 
-        {loading ? (
+      {loading ? (
         // Display the loading spinner while the request is being processed
         <View className="mt-4 flex items-center">
           <ActivityIndicator size="large" color="#FF6F61" />
@@ -119,10 +136,13 @@ const MushroomDetail = ({ route, navigation }) => {
         </View>
       ) : (
         response ? (
-          <Text className="mt-4 pb-12 border border-gray-300 rounded">{response}</Text>
+          <>
+            <Markdown className="mt-4 pb-12">{response}</Markdown>
+            <Disclaimer />
+          </>
         ) : null
       )}
-      </ScrollView>
+    </ScrollView>
   );
 };
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3434,6 +3434,11 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
 env-editor@^0.4.1:
   version "0.4.2"
   resolved "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz"
@@ -4908,6 +4913,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz"
@@ -5010,6 +5022,17 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 marky@^1.2.2:
   version "1.2.5"
   resolved "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz"
@@ -5044,6 +5067,11 @@ md5hex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz"
   integrity sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -6043,7 +6071,7 @@ prompts@^2.3.2, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6155,6 +6183,13 @@ react-is@^18.1.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-native-fit-image@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/react-native-fit-image/-/react-native-fit-image-1.5.5.tgz"
+  integrity sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg==
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-gesture-handler@^2.20.0:
   version "2.20.0"
   resolved "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.20.0.tgz"
@@ -6164,6 +6199,16 @@ react-native-gesture-handler@^2.20.0:
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
     prop-types "^15.7.2"
+
+react-native-markdown-display@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.npmjs.org/react-native-markdown-display/-/react-native-markdown-display-7.0.2.tgz"
+  integrity sha512-Mn4wotMvMfLAwbX/huMLt202W5DsdpMO/kblk+6eUs55S57VVNni1gzZCh5qpznYLjIQELNh50VIozEfY6fvaQ==
+  dependencies:
+    css-to-react-native "^3.0.0"
+    markdown-it "^10.0.0"
+    prop-types "^15.7.2"
+    react-native-fit-image "^1.5.5"
 
 react-native-paper@^5.12.5:
   version "5.12.5"
@@ -6212,7 +6257,7 @@ react-native-vector-icons@*, react-native-vector-icons@^10.2.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native@*, react-native@>=0.57, react-native@0.74.5:
+react-native@*, react-native@>=0.50.4, react-native@>=0.57, react-native@0.74.5:
   version "0.74.5"
   resolved "https://registry.npmjs.org/react-native/-/react-native-0.74.5.tgz"
   integrity sha512-Bgg2WvxaGODukJMTZFTZBNMKVaROHLwSb8VAGEdrlvKwfb1hHg/3aXTUICYk7dwgAnb+INbGMwnF8yeAgIUmqw==
@@ -6268,7 +6313,7 @@ react-shallow-renderer@^16.15.0:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
-react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@>=16.0, react@>=16.3.0, react@>=16.8, react@>=17.0.0, react@18.2.0:
+react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@>=16.0, react@>=16.2.0, react@>=16.3.0, react@>=16.8, react@>=17.0.0, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -7285,6 +7330,11 @@ ua-parser-js@^1.0.35:
   version "1.0.38"
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz"
   integrity sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This pull request is to:

- Allow a user to click on a post in the homepage (which includes an uploaded or scanned mushroom and its data) to retrieve more information about it, such as Recipes, Info, and Locations (Where to find). Essentially when a user clicks on a post they've created via photo upload/scan, they are directed to the MushroomDetail page, which has the OpenAI integration to generate species and recipe information. 
- Also included a more prominent legal disclaimer section.
- Made some styling changes in the MushroomDetail Page e.g. adding Markdown to format OpenAI response
- Possibly might also add a save item button, to save retrieved information into the Bookmarks page. 
